### PR TITLE
Building for mac os

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
     name: Mac build for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         
       - name: Build macos image
-        run: |
-          npm install -g @bazel/bazelisk
-          pip_package/macos_build.sh
+        run: pip_package/macos_build.sh
 
       - name: Upload .whl artifacts
         uses: actions/upload-artifact@v2.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6 3.7 3.8 ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
     name: Mac build for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [ '3.5' ]
+        python-version: [ 3.5, 3.6 ]
     name: Mac build for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: "/Users/runner/.cache/bazel"
-          key: macos-bazel
+          key: ${{ runner.os }}-bazel
       - run: pip_package/macos_build.sh
 
       - name: Upload .whl artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9.0-rc.2 ]
     name: Mac build for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Mount bazel cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: "/Users/runner/.cache/bazel"
           key: ${{ runner.os }}-bazel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6 ]
+        python-version: [ 3.5, 3.6 3.7 3.8 ]
     name: Mac build for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "/Users/runner/.cache/bazel"
+          key: macos-bazel
       - run: pip_package/macos_build.sh
 
       - name: Upload .whl artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,4 @@
 # This is a flow that builds binary wheels for PyPI
-
 name: pypi_build
 
 # Trigger the workflow on push or pull request events master
@@ -10,9 +9,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  manylinux_build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
         
@@ -25,6 +23,21 @@ jobs:
         uses: actions/upload-artifact@v2.1.4
         with:
           name: python_wheels
-          path: embag-*.whl 
+          path: embag-*.whl
+  macos_build:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+        
+      - name: Build macos image
+        run: |
+          npm install -g @bazel/bazelisk
+          pip_package/macos_build.sh
+
+      - name: Upload .whl artifacts
+        uses: actions/upload-artifact@v2.1.4
+        with:
+          name: python_wheels
+          path: /tmp/out/embag-*.whl
           
       

--- a/pip_package/macos_build.sh
+++ b/pip_package/macos_build.sh
@@ -11,7 +11,7 @@ bazel test test:* --test_output=all
 
 # Build wheel
 cp bazel-bin/python/libembag.so /tmp/pip_build/embag
-(cd /tmp/pip_build && $PYTHON_PATH setup.py bdist_wheel && \
+(cd /tmp/pip_build && python setup.py bdist_wheel && \
  python -m pip install dist/embag*.whl && \
  python -c 'import embag; embag.View(); print("Successfully loaded embag!")' &&\
  cp dist/* /tmp/out && \

--- a/pip_package/macos_build.sh
+++ b/pip_package/macos_build.sh
@@ -5,7 +5,7 @@ cp -r lib /tmp/embag
 cp -r pip_package/* README.md LICENSE /tmp/pip_build
 
 # Build embag for various version of Python
-for version in 3.8
+for version in 3.5 3.6 3.7 3.8
   do
     # Build embag libs and echo test binary
     PYTHON_PATH=`which python$version`

--- a/pip_package/macos_build.sh
+++ b/pip_package/macos_build.sh
@@ -1,25 +1,19 @@
 #!/bin/bash -e
 
-mkdir /tmp/embag /tmp/pip_build /tmp/out
+mkdir -p /tmp/embag /tmp/pip_build /tmp/out
 cp -r lib /tmp/embag
 cp -r pip_package/* README.md LICENSE /tmp/pip_build
 
-# Build embag for various version of Python
-for version in 3.5 3.6 3.7 3.8
-  do
-    # Build embag libs and echo test binary
-    PYTHON_PATH=`which python$version`
-    PYTHON_BIN_PATH=$PYTHON_PATH bazel build //python:libembag.so //embag_echo:embag_echo && \
+# Build embag libs and echo test binary
+bazel build //python:libembag.so //embag_echo:embag_echo && \
 
-    # FIXME: This may not run with the correct version of python...
-    bazel test test:* --test_output=all
+bazel test test:* --test_output=all
 
-    # Build wheel
-    cp bazel-bin/python/libembag.so /tmp/pip_build/embag
-    (cd /tmp/pip_build && $PYTHON_PATH setup.py bdist_wheel && \
-     $PYTHON_PATH -m pip install dist/embag*.whl && \
-     $PYTHON_PATH -c 'import embag; embag.View(); print("Successfully loaded embag!")' &&\
-     cp dist/* /tmp/out && \
-     rm -rf build dist)
-  done
+# Build wheel
+cp bazel-bin/python/libembag.so /tmp/pip_build/embag
+(cd /tmp/pip_build && $PYTHON_PATH setup.py bdist_wheel && \
+ python -m pip install dist/embag*.whl && \
+ python -c 'import embag; embag.View(); print("Successfully loaded embag!")' &&\
+ cp dist/* /tmp/out && \
+ rm -rf build dist)
 

--- a/pip_package/macos_build.sh
+++ b/pip_package/macos_build.sh
@@ -6,11 +6,11 @@ cp -r pip_package/* README.md LICENSE /tmp/pip_build
 
 # Build embag libs and echo test binary
 bazel build //python:libembag.so //embag_echo:embag_echo && \
-
 bazel test test:* --test_output=all
 
 # Build wheel
 cp bazel-bin/python/libembag.so /tmp/pip_build/embag
+python -m pip install wheel
 (cd /tmp/pip_build && python setup.py bdist_wheel && \
  python -m pip install dist/embag*.whl && \
  python -c 'import embag; embag.View(); print("Successfully loaded embag!")' &&\

--- a/pip_package/macos_build.sh
+++ b/pip_package/macos_build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+mkdir /tmp/embag /tmp/pip_build /tmp/out
+cp -r lib /tmp/embag
+cp -r pip_package/* README.md LICENSE /tmp/pip_build
+
+# Build embag for various version of Python
+for version in 3.8
+  do
+    # Build embag libs and echo test binary
+    PYTHON_PATH=`which python$version`
+    PYTHON_BIN_PATH=$PYTHON_PATH bazel build //python:libembag.so //embag_echo:embag_echo && \
+
+    # FIXME: This may not run with the correct version of python...
+    bazel test test:* --test_output=all
+
+    # Build wheel
+    cp bazel-bin/python/libembag.so /tmp/pip_build/embag
+    (cd /tmp/pip_build && $PYTHON_PATH setup.py bdist_wheel && \
+     $PYTHON_PATH -m pip install dist/embag*.whl && \
+     $PYTHON_PATH -c 'import embag; embag.View(); print("Successfully loaded embag!")' &&\
+     cp dist/* /tmp/out && \
+     rm -rf build dist)
+  done
+


### PR DESCRIPTION
The GitHub Actions build now supports binary wheels for MacOS (3.5-3.9).