### PR TITLE
Make bag_offset_compare_t const-invocable

### DIFF
--- a/lib/view.h
+++ b/lib/view.h
@@ -75,7 +75,7 @@ class View {
 
       // Function for comparing bag offsets
       struct bag_offset_compare_t {
-        bool operator()(const RosBagTypes::chunk_t *left, const RosBagTypes::chunk_t *right) {
+        bool operator()(const RosBagTypes::chunk_t *left, const RosBagTypes::chunk_t *right) const {
           return left->offset < right->offset;
         }
       };


### PR DESCRIPTION
Makes std::set compile with gcc 8.4 (not sure what other versions it does or doesn't compile with)