### PR TITLE
Expose embag's headers under embag/

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -3,6 +3,27 @@ load("//lib:version.bzl", "EMBAG_VERSION")
 
 cc_library(
     name = "embag",
+    include_prefix = "embag",
+    visibility = ["//visibility:public"],
+    hdrs = [
+        "decompression.h",
+        "embag.h",
+        "message_parser.h",
+        "ros_bag_types.h",
+        "ros_message.h",
+        "ros_msg_types.h",
+        "ros_value.h",
+        "span.hpp",
+        "view.h",
+        "util.h",
+    ],
+    deps = [
+        ":embag_internal",
+    ],
+)
+
+cc_library(
+    name = "embag_internal",
     srcs = [
         "embag.cc",
         "message_parser.cc",
@@ -25,7 +46,6 @@ cc_library(
     linkopts = [
         "-lstdc++",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "@boost//:fusion",
         "@boost//:iostreams",


### PR DESCRIPTION
Users of the library can now do `#include "embag/embag.h"` instead of `#include "lib/embag.h"` (or worse, `#include "embag.h"` which also means `util.h` and `span.hpp` can now conflict with other includes in a project)