### PR TITLE
[Bazel] LZ4 library needs to depend on its headers

### DIFF
--- a/lz4/BUILD
+++ b/lz4/BUILD
@@ -32,10 +32,10 @@ cc_library(
     hdrs = [
         "lib/lz4hc.h",
     ],
-    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:public"],
     deps = [
+        ":hdrs",
         ":lz4",
         ":lz4_lz4c_include",
     ],

--- a/lz4/BUILD
+++ b/lz4/BUILD
@@ -8,6 +8,7 @@ cc_library(
     hdrs = [
         "lib/lz4.h",
     ],
+    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:public"],
 )
@@ -18,6 +19,7 @@ cc_library(
     hdrs = [
         "lib/lz4.c",
     ],
+    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:private"],
 )
@@ -30,6 +32,7 @@ cc_library(
     hdrs = [
         "lib/lz4hc.h",
     ],
+    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:public"],
     deps = [
@@ -47,10 +50,16 @@ cc_library(
     hdrs = [
         "lib/lz4frame.h",
     ],
+    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:public"],
     deps = [
         ":lz4",
         ":lz4_hc",
     ],
+)
+
+cc_library(
+    name = "hdrs",
+    hdrs = glob(["lib/*.h"]) + ["lib/lz4.c"],
 )

--- a/lz4/BUILD
+++ b/lz4/BUILD
@@ -50,10 +50,10 @@ cc_library(
     hdrs = [
         "lib/lz4frame.h",
     ],
-    deps = [":hdrs"],
     strip_include_prefix = "lib/",
     visibility = ["//visibility:public"],
     deps = [
+        ":hdrs",
         ":lz4",
         ":lz4_hc",
     ],


### PR DESCRIPTION
Not sure if this is a bazel version mismatch or what, but bazel 1.0.0 needs these changes to compile properly. Otherwise it complains about undeclared dependencies on these includes (and the one C file)