### PR TITLE
Make connections' info accessible from Python

### DIFF
--- a/lib/embag.h
+++ b/lib/embag.h
@@ -64,6 +64,10 @@ class Bag {
     return topic_connection_map_[topic];
   }
 
+  const std::unordered_map<std::string, std::vector<RosBagTypes::connection_record_t *>> &connectionsByTopicMap() const {
+    return topic_connection_map_;
+  }
+
  private:
   const std::string MAGIC_STRING = "#ROSBAG V";
 


### PR DESCRIPTION
Description of Changes
======================
This PR adds a `connectionsByTopic()` method to `Bag` and `View` in Python. Also a `topics()` method to `View` for consistency with `Bag`.
`embag` is a fantastic library and the speed difference with `rosbag` is crazy, but when using the Python interface I tend to miss the access to connections' metadata that is provided in `rosbag`. Particularly the message type info, which allows topics to be selected dynamically by type rather by name. The connections info was already readily available in the C++ classes anyway and just needed to be exposed in Python.

Test Plan
=========
I added some simple unit tests for Python.
