### PR TITLE
getSchema() improvements

### DIFF
--- a/lib/view.cc
+++ b/lib/view.cc
@@ -243,6 +243,7 @@ View View::addBag(const std::string &filename) {
 
 View View::addBag(std::shared_ptr<Bag> bag) {
   bags_.emplace_back(bag);
+  connections_by_topic_.clear();
   return *this;
 }
 }

--- a/lib/view.h
+++ b/lib/view.h
@@ -137,13 +137,15 @@ class View {
     return std::vector<std::string>(topics.begin(), topics.end());
   }
 
-  std::unordered_map<std::string, std::vector<RosBagTypes::connection_data_t>> connectionsByTopicMap() const {
-    std::unordered_map<std::string, std::vector<RosBagTypes::connection_data_t>> connections_by_topic;
+  const std::unordered_map<std::string, std::vector<RosBagTypes::connection_data_t>> &connectionsByTopicMap() const {
+    if (!connections_by_topic_.empty()) {
+      return connections_by_topic_;
+    }
     for (const auto &bag : bags_) {
       for (const auto &item : bag->connectionsByTopicMap()) {
         const auto &topic = item.first;
         const auto &new_conns = item.second;
-        auto &existing_conns = connections_by_topic[topic];
+        auto &existing_conns = connections_by_topic_[topic];
         for (const auto &new_c : new_conns) {
           auto existing_it = std::find(existing_conns.begin(), existing_conns.end(), new_c);
           if (existing_it == existing_conns.end()) {
@@ -154,11 +156,12 @@ class View {
         }
       }
     }
-    return connections_by_topic;
+    return connections_by_topic_;
   }
 
  private:
   std::vector<std::shared_ptr<Bag>> bags_;
   std::unordered_map<std::shared_ptr<Bag>, std::shared_ptr<iterator::bag_wrapper_t>> bag_wrappers_;
+  mutable std::unordered_map<std::string, std::vector<RosBagTypes::connection_data_t>> connections_by_topic_;
 };
 }

--- a/lib/view.h
+++ b/lib/view.h
@@ -159,6 +159,15 @@ class View {
     return connections_by_topic_;
   }
 
+  std::shared_ptr<RosMsgTypes::ros_msg_def> msgDefForTopic(const std::string &topic) {
+    for (const auto &bag : bags_) {
+      if (bag->topicInBag(topic)) {
+        return bag->msgDefForTopic(topic);
+      }
+    }
+    throw std::runtime_error("Unable to find topic in bags: " + topic);
+  }
+
  private:
   std::vector<std::shared_ptr<Bag>> bags_;
   std::unordered_map<std::shared_ptr<Bag>, std::shared_ptr<iterator::bag_wrapper_t>> bag_wrappers_;

--- a/pip_package/embag/__init__.py
+++ b/pip_package/embag/__init__.py
@@ -1,1 +1,1 @@
-from embag.libembag import View, Bag
+from embag.libembag import View, Bag, getSchema

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -26,9 +26,8 @@ PYBIND11_MODULE(libembag, m) {
 
         return py::make_iterator(IteratorCompat{view.begin()}, IteratorCompat{view.end()});
       }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */, py::arg("topics"))
-      .def("getSchema", [](std::shared_ptr<Embag::Bag> &bag, const std::string &topic) {
-        auto builder = SchemaBuilder{bag};
-        return builder.generateSchema(topic);
+      .def("getSchema", [](Embag::Bag &bag, const std::string &topic) {
+        return SchemaBuilder(bag, topic).generateSchema();
       })
       .def("connectionsByTopic", &Embag::Bag::connectionsByTopicMap)
       .def("close", &Embag::Bag::close);
@@ -48,6 +47,9 @@ PYBIND11_MODULE(libembag, m) {
         return py::make_iterator(v.begin(), v.end());
       }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */ )
       .def("topics", &Embag::View::topics)
+      .def("getSchema", [](Embag::View &view, const std::string &topic) {
+        return SchemaBuilder(view, topic).generateSchema();
+      })
       .def("connectionsByTopic", &Embag::View::connectionsByTopicMap);
 
   py::class_<Embag::RosMessage, std::shared_ptr<Embag::RosMessage>>(m, "RosMessage", py::dynamic_attr())
@@ -130,4 +132,9 @@ PYBIND11_MODULE(libembag, m) {
       .def("__repr__", [](const Embag::RosBagTypes::connection_data_t &c) {
         return "<embag.Connection '" + c.type + "' from '" + c.callerid + "'>";
       });
+
+  m.def("getSchema", [](const std::string &message_type,
+                        const std::string &message_definition) {
+    return SchemaBuilder(message_type, message_definition).generateSchema();
+  });
 }

--- a/python/schema_builder.h
+++ b/python/schema_builder.h
@@ -8,14 +8,17 @@ namespace py = pybind11;
 
 class SchemaBuilder {
  public:
-  explicit SchemaBuilder(std::shared_ptr<Embag::Bag> &bag) : bag_(bag) {};
+  SchemaBuilder(Embag::View &view, const std::string &topic);
+  SchemaBuilder(Embag::Bag &bag, const std::string &topic);
+  SchemaBuilder(const std::string &message_type,
+                const std::string &message_definition);
 
-  py::object generateSchema(const std::string &topic);
+  py::object generateSchema();
 
- private:
+private:
   py::dict schemaForField(const std::string &scope, const Embag::RosMsgTypes::ros_msg_field &field) const;
 
-  std::shared_ptr<Embag::Bag> bag_;
+  std::string outer_scope_;
   std::shared_ptr<Embag::RosMsgTypes::ros_msg_def> msg_def_;
   const py::object ordered_dict_ = py::module::import("collections").attr("OrderedDict");
 };

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -51,7 +51,15 @@ class EmbagTest(unittest.TestCase):
             ('is_dense', {'type': 'bool'})
         ])
 
-        schema = self.bag.getSchema('/luminar_pointcloud')
+        topic = '/luminar_pointcloud'
+        schema = self.bag.getSchema(topic)
+        self.assertDictEqual(schema, known_schema)
+
+        schema = self.view.getSchema(topic)
+        self.assertDictEqual(schema, known_schema)
+
+        c = self.bag.connectionsByTopic()[topic][0]
+        schema = embag.getSchema(c.type, c.message_definition)
         self.assertDictEqual(schema, known_schema)
 
     def testTopicsInBag(self):


### PR DESCRIPTION
Description of Changes
======================
This PR makes the `getSchema()` method also available from `View` in addition to `Bag` and also introduces a standalone version with the signature `getSchema(message_type: str, message_definition: str)`.

Test Plan
=========
Added relevant unit tests to Python.