### PR TITLE
Fix Embag Memory Leaks

### DIFF
--- a/lib/message_parser.cc
+++ b/lib/message_parser.cc
@@ -9,7 +9,7 @@
 
 namespace Embag {
 
-const RosValue* MessageParser::parse() {
+const RosValue::RosValuePointer MessageParser::parse() {
   // The lowest number of RosValues occurs when we have a message with only doubles in a single type.
   // The number of RosValues in this case is the number of doubles that can fit in our buffer,
   // plus one for the RosValue object that will point to all the doubles.
@@ -17,7 +17,7 @@ const RosValue* MessageParser::parse() {
   ros_values_->emplace_back(msg_def_.fieldIndexes());
   ros_values_offset_ = 1;
   initObject(0, msg_def_);
-  return &ros_values_->front();
+  return RosValue::RosValuePointer(ros_values_, 0);
 }
 
 void MessageParser::initObject(size_t object_offset, const RosMsgTypes::BaseMsgDef &object_definition) {

--- a/lib/message_parser.cc
+++ b/lib/message_parser.cc
@@ -17,7 +17,7 @@ const RosValue::RosValuePointer MessageParser::parse() {
   ros_values_->emplace_back(msg_def_.fieldIndexes());
   ros_values_offset_ = 1;
   initObject(0, msg_def_);
-  return RosValue::RosValuePointer(ros_values_, 0);
+  return RosValue::RosValuePointer(ros_values_);
 }
 
 void MessageParser::initObject(size_t object_offset, const RosMsgTypes::BaseMsgDef &object_definition) {

--- a/lib/message_parser.h
+++ b/lib/message_parser.h
@@ -24,7 +24,7 @@ class MessageParser {
   {
   };
 
-  const RosValue* parse();
+  const RosValue::RosValuePointer parse();
 
  private:
   static std::unordered_map<std::string, size_t> primitive_size_map_;

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -24,12 +24,12 @@ class RosMessage {
   {
   }
 
-  const RosValue &data() {
+  const RosValue::RosValuePointer &data() {
     if (!parsed_) {
       hydrate();
     }
 
-    return *data_;
+    return data_;
   }
 
   bool has(const std::string &key) {
@@ -58,7 +58,7 @@ class RosMessage {
 
  private:
   bool parsed_ = false;
-  const RosValue* data_;
+  RosValue::RosValuePointer data_;
   std::shared_ptr<RosMsgTypes::MsgDef> msg_def_;
 
   void hydrate() {

--- a/lib/ros_value.cc
+++ b/lib/ros_value.cc
@@ -5,23 +5,23 @@
 
 namespace Embag {
 
-const RosValue &RosValue::operator()(const std::string &key) const {
+const RosValue::RosValuePointer RosValue::operator()(const std::string &key) const {
   return get(key);
 }
 
-const RosValue &RosValue::operator[](const std::string &key) const {
+const RosValue::RosValuePointer RosValue::operator[](const std::string &key) const {
   return get(key);
 }
 
-const RosValue &RosValue::operator[](const size_t idx) const {
+const RosValue::RosValuePointer RosValue::operator[](const size_t idx) const {
   return at(idx);
 }
 
-const RosValue &RosValue::at(const std::string &key) const {
+const RosValue::RosValuePointer RosValue::at(const std::string &key) const {
   return get(key);
 }
 
-const RosValue &RosValue::get(const std::string &key) const {
+const RosValue::RosValuePointer RosValue::get(const std::string &key) const {
   if (type_ != Type::object) {
     throw std::runtime_error("Value is not an object");
   }
@@ -40,7 +40,7 @@ const std::string RosValue::as<std::string>() const {
   return std::string(string_loc, string_loc + string_length);
 }
 
-const RosValue &RosValue::at(const size_t idx) const {
+const RosValue::RosValuePointer RosValue::at(const size_t idx) const {
   if (type_ != Type::array) {
     throw std::runtime_error("Value is not an array");
   }
@@ -99,13 +99,13 @@ std::string RosValue::toString(const std::string &path) const {
       std::ostringstream output;
       for (const auto& field : *object_info_.field_indexes) {
         if (path.empty()) {
-          output << object_info_.children.at(field.second).toString(field.first);
+          output << object_info_.children.at(field.second)->toString(field.first);
         } else {
-          output << object_info_.children.at(field.second).toString(path + "." + field.first);
+          output << object_info_.children.at(field.second)->toString(path + "." + field.first);
         }
 
         // No need for a newline if our child is an object or array
-        const auto &object_type = object_info_.children.at(field.second).getType();
+        const auto &object_type = object_info_.children.at(field.second)->getType();
         if (!(object_type == Type::object || object_type == Type::array)) {
           output << std::endl;
         }
@@ -116,7 +116,7 @@ std::string RosValue::toString(const std::string &path) const {
       std::ostringstream output;
       for (size_t i = 0; i < array_info_.children.length; ++i) {
         const std::string array_path = path + "[" + std::to_string(i) + "]";
-        output << array_info_.children.at(i).toString(array_path) << std::endl;
+        output << array_info_.children.at(i)->toString(array_path) << std::endl;
       }
       return output.str();
     }
@@ -141,7 +141,7 @@ const std::string& RosValue::const_iterator<const std::string&, std::unordered_m
 }
 
 template<>
-const std::pair<const std::string&, const RosValue&> RosValue::const_iterator<const std::pair<const std::string&, const RosValue&>, std::unordered_map<std::string, size_t>::const_iterator>::operator*() const {
+const std::pair<const std::string&, const RosValue::RosValuePointer> RosValue::const_iterator<const std::pair<const std::string&, const RosValue::RosValuePointer>, std::unordered_map<std::string, size_t>::const_iterator>::operator*() const {
   return std::make_pair(index_->first, value_.object_info_.children.at(index_->second));
 }
 

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -20,7 +20,12 @@ class RosValue {
     {
     }
 
-    RosValuePointer(std::weak_ptr<std::vector<RosValue>> base, size_t index)
+    RosValuePointer(const std::weak_ptr<std::vector<RosValue>>& base)
+      : RosValuePointer(base, 0)
+    {
+    }
+
+    RosValuePointer(const std::weak_ptr<std::vector<RosValue>>& base, size_t index)
       : VectorItemPointer<RosValue>(base.lock(), index)
     {
     }

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -13,16 +13,6 @@ namespace Embag {
 
 class RosValue {
  public:
-  struct ros_value_list_t {
-    std::shared_ptr<std::vector<RosValue>> base;
-    size_t offset;
-    size_t length;
-
-    const RosValue& at(size_t index) const {
-      return base->at(offset + index);
-    }
-  };
-
   struct RosValuePointer {
     std::shared_ptr<std::vector<RosValue>> base;
     size_t index;
@@ -33,12 +23,32 @@ class RosValue {
     {
     }
 
+    RosValuePointer(std::weak_ptr<std::vector<RosValue>> base, size_t index)
+    : RosValuePointer(base.lock(), index)
+    {
+    }
+
+    RosValuePointer()
+    : index(0)
+    {
+    }
+
     const RosValue *operator->() const {
       return &base->at(index);
     }
 
     const RosValue& operator*() const {
       return base->at(index);
+    }
+  };
+
+  struct ros_value_list_t {
+    std::weak_ptr<std::vector<RosValue>> base;
+    size_t offset;
+    size_t length;
+
+    const RosValuePointer at(size_t index) const {
+      return RosValuePointer(base, offset + index);
     }
   };
 
@@ -244,12 +254,12 @@ class RosValue {
 
 
   // Convenience accessors
-  const RosValue &operator()(const std::string &key) const;
-  const RosValue &operator[](const std::string &key) const;
-  const RosValue &operator[](const size_t idx) const;
-  const RosValue &get(const std::string &key) const;
-  const RosValue &at(size_t idx) const;
-  const RosValue &at(const std::string &key) const;
+  const RosValuePointer operator()(const std::string &key) const;
+  const RosValuePointer operator[](const std::string &key) const;
+  const RosValuePointer operator[](const size_t idx) const;
+  const RosValuePointer get(const std::string &key) const;
+  const RosValuePointer at(size_t idx) const;
+  const RosValuePointer at(const std::string &key) const;
 
   template<typename T>
   const T &getValue(const std::string &key) const {

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -11,36 +11,50 @@
 
 namespace Embag {
 
+template<class T>
+class VectorItemPointer {
+  std::shared_ptr<std::vector<T>> base;
+  size_t index;
+
+ public:
+  VectorItemPointer(std::shared_ptr<std::vector<T>> base, size_t index)
+  : base(base)
+  , index(index)
+  {
+  }
+
+  VectorItemPointer(std::weak_ptr<std::vector<T>> base, size_t index)
+  : VectorItemPointer(base.lock(), index)
+  {
+  }
+
+  VectorItemPointer(T*& ref)
+  : VectorItemPointer()
+  {
+    throw std::runtime_error("This should never be called");
+  }
+
+  VectorItemPointer()
+  : index(0)
+  {
+  }
+
+  const T *operator->() const {
+    return get();
+  }
+
+  const T* get() const {
+    return &base->at(index);
+  }
+
+  const T& operator*() const {
+    return base->at(index);
+  }
+};
+
 class RosValue {
  public:
-  struct RosValuePointer {
-    std::shared_ptr<std::vector<RosValue>> base;
-    size_t index;
-
-    RosValuePointer(std::shared_ptr<std::vector<RosValue>> base, size_t index)
-    : base(base)
-    , index(index)
-    {
-    }
-
-    RosValuePointer(std::weak_ptr<std::vector<RosValue>> base, size_t index)
-    : RosValuePointer(base.lock(), index)
-    {
-    }
-
-    RosValuePointer()
-    : index(0)
-    {
-    }
-
-    const RosValue *operator->() const {
-      return &base->at(index);
-    }
-
-    const RosValue& operator*() const {
-      return base->at(index);
-    }
-  };
+  typedef VectorItemPointer<RosValue> RosValuePointer;
 
   struct ros_value_list_t {
     std::weak_ptr<std::vector<RosValue>> base;

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -8,53 +8,35 @@
 #include <vector>
 
 #include "span.hpp"
+#include "util.h"
 
 namespace Embag {
 
-template<class T>
-class VectorItemPointer {
-  std::shared_ptr<std::vector<T>> base;
-  size_t index;
-
- public:
-  VectorItemPointer(std::shared_ptr<std::vector<T>> base, size_t index)
-  : base(base)
-  , index(index)
-  {
-  }
-
-  VectorItemPointer(std::weak_ptr<std::vector<T>> base, size_t index)
-  : VectorItemPointer(base.lock(), index)
-  {
-  }
-
-  VectorItemPointer(T*& ref)
-  : VectorItemPointer()
-  {
-    throw std::runtime_error("This should never be called");
-  }
-
-  VectorItemPointer()
-  : index(0)
-  {
-  }
-
-  const T *operator->() const {
-    return get();
-  }
-
-  const T* get() const {
-    return &base->at(index);
-  }
-
-  const T& operator*() const {
-    return base->at(index);
-  }
-};
-
 class RosValue {
  public:
-  typedef VectorItemPointer<RosValue> RosValuePointer;
+  class RosValuePointer : public VectorItemPointer<RosValue> {
+   public:
+    RosValuePointer()
+    {
+    }
+
+    RosValuePointer(std::weak_ptr<std::vector<RosValue>> base, size_t index)
+      : VectorItemPointer<RosValue>(base.lock(), index)
+    {
+    }
+
+    const RosValue operator()(const std::string &key) const {
+      return (*this)(key);
+    }
+
+    const RosValue operator[](const std::string &key) const {
+      return (*this)[key];
+    }
+
+    const RosValue operator[](const size_t idx) const {
+      return (*this)[idx];
+    }
+  };
 
   struct ros_value_list_t {
     std::weak_ptr<std::vector<RosValue>> base;

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -25,16 +25,16 @@ class RosValue {
     {
     }
 
-    const RosValue operator()(const std::string &key) const {
-      return (*this)(key);
+    const RosValuePointer operator()(const std::string &key) const {
+      return (**this)(key);
     }
 
-    const RosValue operator[](const std::string &key) const {
-      return (*this)[key];
+    const RosValuePointer operator[](const std::string &key) const {
+      return (**this)[key];
     }
 
-    const RosValue operator[](const size_t idx) const {
-      return (*this)[idx];
+    const RosValuePointer operator[](const size_t idx) const {
+      return (**this)[idx];
     }
   };
 

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -277,7 +277,7 @@ class RosValue {
 
   template<typename T>
   const T &getValue(const std::string &key) const {
-    return get(key).as<T>();
+    return get(key)->as<T>();
   }
 
   template<typename T>

--- a/lib/util.h
+++ b/lib/util.h
@@ -37,13 +37,13 @@ class VectorItemPointer {
   size_t index;
 
  public:
-  VectorItemPointer(std::shared_ptr<std::vector<T>> base, size_t index)
+  VectorItemPointer(const std::shared_ptr<std::vector<T>>& base, size_t index)
   : base(base)
   , index(index)
   {
   }
 
-  VectorItemPointer(std::weak_ptr<std::vector<T>> base, size_t index)
+  VectorItemPointer(const std::weak_ptr<std::vector<T>>& base, size_t index)
   : VectorItemPointer(base.lock(), index)
   {
   }

--- a/lib/util.h
+++ b/lib/util.h
@@ -11,4 +11,70 @@ std::unique_ptr<T> make_unique(Args &&... args) {
 }
 
 using message_stream = boost::iostreams::stream<boost::iostreams::array_source>;
+
+template<class T>
+class VectorItemPointer;
+
+}
+
+namespace pybind11 { namespace detail {
+  template<class Holder>
+  struct holder_helper;
+  
+  template <class T>
+  struct holder_helper<Embag::VectorItemPointer<T>> {
+    static const T* get(const Embag::VectorItemPointer<T> &vip) {
+      return vip.get();
+    }
+  };
+}}
+
+namespace Embag {
+
+template<class T>
+class VectorItemPointer {
+  std::shared_ptr<std::vector<T>> base;
+  size_t index;
+
+ public:
+  VectorItemPointer(std::shared_ptr<std::vector<T>> base, size_t index)
+  : base(base)
+  , index(index)
+  {
+  }
+
+  VectorItemPointer(std::weak_ptr<std::vector<T>> base, size_t index)
+  : VectorItemPointer(base.lock(), index)
+  {
+  }
+
+  VectorItemPointer(T*& ref)
+  : VectorItemPointer()
+  {
+    throw std::runtime_error("This should never be called");
+  }
+
+  VectorItemPointer()
+  : index(0)
+  {
+  }
+
+  const T* operator->() const {
+    return get();
+  }
+
+ protected:
+  // We don't want any public interface that exposes the underlying item as without
+  // a shared_ptr to the vector that contains the item, the memory may be freed.
+  friend const T* pybind11::detail::holder_helper<VectorItemPointer<T>>::get(const VectorItemPointer<T>& vip);
+
+  const T* get() const {
+    return &**this;
+  }
+
+  const T& operator*() const {
+    return base->at(index);
+  }
+};
+
 }

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -6,10 +6,10 @@
 
 namespace py = pybind11;
 
-py::dict rosValueToDict(const Embag::RosValue::RosValuePointer &ros_value);
-py::list rosValueToList(const Embag::RosValue::RosValuePointer &ros_value);
+py::dict rosValueToDict(const Embag::VectorItemPointer<Embag::RosValue> &ros_value);
+py::list rosValueToList(const Embag::VectorItemPointer<Embag::RosValue> &ros_value);
 
-py::list rosValueToList(const Embag::RosValue::RosValuePointer &ros_value) {
+py::list rosValueToList(const Embag::VectorItemPointer<Embag::RosValue> &ros_value) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::array) {
@@ -94,7 +94,7 @@ py::list rosValueToList(const Embag::RosValue::RosValuePointer &ros_value) {
   return list;
 }
 
-py::dict rosValueToDict(const Embag::RosValue::RosValuePointer &ros_value) {
+py::dict rosValueToDict(const Embag::VectorItemPointer<Embag::RosValue> &ros_value) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::object) {
@@ -183,7 +183,7 @@ py::dict rosValueToDict(const Embag::RosValue::RosValuePointer &ros_value) {
   return dict;
 }
 
-py::object castValue(const Embag::RosValue::RosValuePointer& value) {
+py::object castValue(const Embag::VectorItemPointer<Embag::RosValue>& value) {
   switch (value->getType()) {
     case Embag::RosValue::Type::object:
     case Embag::RosValue::Type::array:
@@ -222,7 +222,7 @@ py::object castValue(const Embag::RosValue::RosValuePointer& value) {
   }
 }
 
-py::object getField(Embag::RosValue::RosValuePointer &v, const std::string field_name) {
+py::object getField(Embag::VectorItemPointer<Embag::RosValue> &v, const std::string field_name) {
   if (v->getType() != Embag::RosValue::Type::object) {
     throw std::runtime_error("Can only getField on an object");
   }
@@ -230,7 +230,7 @@ py::object getField(Embag::RosValue::RosValuePointer &v, const std::string field
   return castValue(v->get(field_name));
 }
 
-py::object getIndex(Embag::RosValue::RosValuePointer &v, const size_t index) {
+py::object getIndex(Embag::VectorItemPointer<Embag::RosValue> &v, const size_t index) {
   if (v->getType() != Embag::RosValue::Type::array) {
     throw std::runtime_error("Can only getIndex on an array");
   }

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -222,7 +222,7 @@ py::object castValue(const Embag::RosValue::RosValuePointer& value) {
   }
 }
 
-py::object getField(std::shared_ptr<Embag::RosValue> &v, const std::string field_name) {
+py::object getField(Embag::RosValue::RosValuePointer &v, const std::string field_name) {
   if (v->getType() != Embag::RosValue::Type::object) {
     throw std::runtime_error("Can only getField on an object");
   }
@@ -230,7 +230,7 @@ py::object getField(std::shared_ptr<Embag::RosValue> &v, const std::string field
   return castValue(v->get(field_name));
 }
 
-py::object getIndex(std::shared_ptr<Embag::RosValue> &v, const size_t index) {
+py::object getIndex(Embag::RosValue::RosValuePointer &v, const size_t index) {
   if (v->getType() != Embag::RosValue::Type::array) {
     throw std::runtime_error("Can only getIndex on an array");
   }

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -6,20 +6,20 @@
 
 namespace py = pybind11;
 
-py::dict rosValueToDict(const Embag::RosValue &ros_value);
-py::list rosValueToList(const Embag::RosValue &ros_value);
+py::dict rosValueToDict(const Embag::RosValue::RosValuePointer &ros_value);
+py::list rosValueToList(const Embag::RosValue::RosValuePointer &ros_value);
 
-py::list rosValueToList(const Embag::RosValue &ros_value) {
+py::list rosValueToList(const Embag::RosValue::RosValuePointer &ros_value) {
   using Type = Embag::RosValue::Type;
 
-  if (ros_value.getType() != Type::array) {
+  if (ros_value->getType() != Type::array) {
     throw std::runtime_error("Provided RosValue is not an array");
   }
 
   py::list list{};
 
   // TODO: Rather than creating a vector, RosValue should provide an iterator interface
-  for (const auto &value : ros_value.getValues()) {
+  for (const auto &value : ros_value->getValues()) {
     switch (value->getType()) {
       case Type::ros_bool: {
         list.append(value->as<bool>());
@@ -78,11 +78,11 @@ py::list rosValueToList(const Embag::RosValue &ros_value) {
         break;
       }
       case Type::object: {
-        list.append(rosValueToDict(*value));
+        list.append(rosValueToDict(value));
         break;
       }
       case Type::array: {
-        list.append(rosValueToList(*value));
+        list.append(rosValueToList(value));
         break;
       }
       default: {
@@ -94,17 +94,17 @@ py::list rosValueToList(const Embag::RosValue &ros_value) {
   return list;
 }
 
-py::dict rosValueToDict(const Embag::RosValue &ros_value) {
+py::dict rosValueToDict(const Embag::RosValue::RosValuePointer &ros_value) {
   using Type = Embag::RosValue::Type;
 
-  if (ros_value.getType() != Type::object) {
+  if (ros_value->getType() != Type::object) {
     throw std::runtime_error("Provided RosValue is not an object");
   }
 
   py::dict dict{};
 
   // TODO: Rather than creating an unordered_map, RosValue should provide an iterator interface
-  for (const auto &element : ros_value.getObjects()) {
+  for (const auto &element : ros_value->getObjects()) {
     const auto &key = element.first.c_str();
     const auto &value = element.second;
 
@@ -167,11 +167,11 @@ py::dict rosValueToDict(const Embag::RosValue &ros_value) {
         break;
       }
       case Type::object: {
-        dict[key] = rosValueToDict(*value);
+        dict[key] = rosValueToDict(value);
         break;
       }
       case Type::array: {
-        dict[key] = rosValueToList(*value);
+        dict[key] = rosValueToList(value);
         break;
       }
       default: {
@@ -183,40 +183,40 @@ py::dict rosValueToDict(const Embag::RosValue &ros_value) {
   return dict;
 }
 
-py::object castValue(const Embag::RosValue& value) {
-  switch (value.getType()) {
+py::object castValue(const Embag::RosValue::RosValuePointer& value) {
+  switch (value->getType()) {
     case Embag::RosValue::Type::object:
     case Embag::RosValue::Type::array:
       return py::cast(value);
     case Embag::RosValue::Type::ros_bool:
-      return py::cast(value.as<bool>());
+      return py::cast(value->as<bool>());
     case Embag::RosValue::Type::int8:
-      return py::cast(value.as<int8_t>());
+      return py::cast(value->as<int8_t>());
     case Embag::RosValue::Type::uint8:
-      return py::cast(value.as<uint8_t>());
+      return py::cast(value->as<uint8_t>());
     case Embag::RosValue::Type::int16:
-      return py::cast(value.as<int16_t>());
+      return py::cast(value->as<int16_t>());
     case Embag::RosValue::Type::uint16:
-      return py::cast(value.as<uint16_t>());
+      return py::cast(value->as<uint16_t>());
     case Embag::RosValue::Type::int32:
-      return py::cast(value.as<int32_t>());
+      return py::cast(value->as<int32_t>());
     case Embag::RosValue::Type::uint32:
-      return py::cast(value.as<uint32_t>());
+      return py::cast(value->as<uint32_t>());
     case Embag::RosValue::Type::int64:
-      return py::cast(value.as<int64_t>());
+      return py::cast(value->as<int64_t>());
     case Embag::RosValue::Type::uint64:
-      return py::cast(value.as<uint64_t>());
+      return py::cast(value->as<uint64_t>());
     case Embag::RosValue::Type::float32:
-      return py::cast(value.as<float>());
+      return py::cast(value->as<float>());
     case Embag::RosValue::Type::float64:
-      return py::cast(value.as<double>());
+      return py::cast(value->as<double>());
     case Embag::RosValue::Type::string:
-      return encodeStrLatin1(value.as<std::string>());
+      return encodeStrLatin1(value->as<std::string>());
     // TODO: Don't return floats here - the raw ros time has more precision
     case Embag::RosValue::Type::ros_time:
-      return py::cast(value.as<Embag::RosValue::ros_time_t>().to_sec());
+      return py::cast(value->as<Embag::RosValue::ros_time_t>().to_sec());
     case Embag::RosValue::Type::ros_duration:
-      return py::cast(value.as<Embag::RosValue::ros_duration_t>().to_sec());
+      return py::cast(value->as<Embag::RosValue::ros_duration_t>().to_sec());
     default:
       throw std::runtime_error("Unhandled type");
   }

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -10,6 +10,8 @@
 
 namespace py = pybind11;
 
+PYBIND11_DECLARE_HOLDER_TYPE(T, Embag::VectorItemPointer<T>);
+
 PYBIND11_MODULE(libembag, m) {
   m.doc() = "Python bindings for Embag";
 
@@ -67,14 +69,14 @@ PYBIND11_MODULE(libembag, m) {
       .def_readonly("md5", &Embag::RosMessage::md5)
       .def_readonly("raw_data_len", &Embag::RosMessage::raw_data_len);
 
-  auto ros_value = py::class_<Embag::RosValue, std::shared_ptr<Embag::RosValue>>(m, "RosValue", py::dynamic_attr())
+  auto ros_value = py::class_<Embag::RosValue, Embag::RosValue::RosValuePointer>(m, "RosValue", py::dynamic_attr())
       .def("get", &Embag::RosValue::get)
       .def("getType", &Embag::RosValue::getType)
       .def("__len__", &Embag::RosValue::size)
-      .def("__str__", [](std::shared_ptr<Embag::RosValue> &v, const std::string &path) {
+      .def("__str__", [](Embag::RosValue::RosValuePointer &v, const std::string &path) {
         return encodeStrLatin1(v->toString());
       }, py::arg("path") = "")
-      .def("__iter__", [](std::shared_ptr<Embag::RosValue> &v) {
+      .def("__iter__", [](Embag::RosValue::RosValuePointer &v) {
         switch (v->getType()) {
           // TODO: Allow object iteration
           case Embag::RosValue::Type::array: {
@@ -84,13 +86,13 @@ PYBIND11_MODULE(libembag, m) {
             throw std::runtime_error("Can only iterate array RosValues");
         }
       }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
-      .def("__getattr__", [](std::shared_ptr<Embag::RosValue> &v, const std::string &attr) {
+      .def("__getattr__", [](Embag::RosValue::RosValuePointer &v, const std::string &attr) {
         return getField(v, attr);
       })
-      .def("__getitem__", [](std::shared_ptr<Embag::RosValue> &v, const std::string &key) {
+      .def("__getitem__", [](Embag::RosValue::RosValuePointer &v, const std::string &key) {
         return getField(v, key);
       })
-      .def("__getitem__", [](std::shared_ptr<Embag::RosValue> &v, const size_t index) {
+      .def("__getitem__", [](Embag::RosValue::RosValuePointer &v, const size_t index) {
         return getIndex(v, index);
       });
 

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -56,7 +56,9 @@ PYBIND11_MODULE(libembag, m) {
       .def("__str__", [](std::shared_ptr<Embag::RosMessage> &m) {
         return encodeStrLatin1(m->toString());
       })
-      .def("data", &Embag::RosMessage::data)
+      .def("data", [](std::shared_ptr<Embag::RosMessage> &m) {
+        return (Embag::VectorItemPointer<Embag::RosValue>&) m->data();
+      })
       .def("dict", [](std::shared_ptr<Embag::RosMessage> &m) {
         if (m->data()->getType() != Embag::RosValue::Type::object) {
           throw std::runtime_error("Element is not an object");
@@ -69,14 +71,14 @@ PYBIND11_MODULE(libembag, m) {
       .def_readonly("md5", &Embag::RosMessage::md5)
       .def_readonly("raw_data_len", &Embag::RosMessage::raw_data_len);
 
-  auto ros_value = py::class_<Embag::RosValue, Embag::RosValue::RosValuePointer>(m, "RosValue", py::dynamic_attr())
+  auto ros_value = py::class_<Embag::RosValue, Embag::VectorItemPointer<Embag::RosValue>>(m, "RosValue", py::dynamic_attr())
       .def("get", &Embag::RosValue::get)
       .def("getType", &Embag::RosValue::getType)
       .def("__len__", &Embag::RosValue::size)
-      .def("__str__", [](Embag::RosValue::RosValuePointer &v, const std::string &path) {
+      .def("__str__", [](Embag::VectorItemPointer<Embag::RosValue> &v, const std::string &path) {
         return encodeStrLatin1(v->toString());
       }, py::arg("path") = "")
-      .def("__iter__", [](Embag::RosValue::RosValuePointer &v) {
+      .def("__iter__", [](Embag::VectorItemPointer<Embag::RosValue> &v) {
         switch (v->getType()) {
           // TODO: Allow object iteration
           case Embag::RosValue::Type::array: {
@@ -86,13 +88,13 @@ PYBIND11_MODULE(libembag, m) {
             throw std::runtime_error("Can only iterate array RosValues");
         }
       }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
-      .def("__getattr__", [](Embag::RosValue::RosValuePointer &v, const std::string &attr) {
+      .def("__getattr__", [](Embag::VectorItemPointer<Embag::RosValue> &v, const std::string &attr) {
         return getField(v, attr);
       })
-      .def("__getitem__", [](Embag::RosValue::RosValuePointer &v, const std::string &key) {
+      .def("__getitem__", [](Embag::VectorItemPointer<Embag::RosValue> &v, const std::string &key) {
         return getField(v, key);
       })
-      .def("__getitem__", [](Embag::RosValue::RosValuePointer &v, const size_t index) {
+      .def("__getitem__", [](Embag::VectorItemPointer<Embag::RosValue> &v, const size_t index) {
         return getIndex(v, index);
       });
 

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -56,7 +56,7 @@ PYBIND11_MODULE(libembag, m) {
       })
       .def("data", &Embag::RosMessage::data)
       .def("dict", [](std::shared_ptr<Embag::RosMessage> &m) {
-        if (m->data().getType() != Embag::RosValue::Type::object) {
+        if (m->data()->getType() != Embag::RosValue::Type::object) {
           throw std::runtime_error("Element is not an object");
         }
 

--- a/python/ros_compat.h
+++ b/python/ros_compat.h
@@ -12,8 +12,12 @@ struct IteratorCompat {
 
   py::tuple operator*() const {
     const auto msg = *iterator_;
-    // TODO: Change the timestamp to a rostime - they have more precision!
-    return py::make_tuple(msg->topic, msg->data(), msg->timestamp.to_sec());
+    return py::make_tuple(
+      msg->topic,
+      (Embag::VectorItemPointer<Embag::RosValue>&) msg->data(),
+      // TODO: Change the timestamp to a rostime - they have more precision!
+      msg->timestamp.to_sec()
+    );
   }
 
   bool operator==(const IteratorCompat &other) const {

--- a/test/embag_test.cc
+++ b/test/embag_test.cc
@@ -173,18 +173,18 @@ TEST_F(ViewTest, AllMessages) {
       ASSERT_GE(message->timestamp.to_sec(), last_scan_ts);
       last_scan_ts = message->timestamp.to_sec();
       ASSERT_EQ(message->md5, "90c7ef2dc6895d81024acba2ac42f369");
-      ASSERT_EQ(message->data()["header"]["seq"].as<uint32_t>(), scan_seq++);
-      ASSERT_EQ(message->data()["header"]["frame_id"].as<std::string>(), "base_laser_link");
-      ASSERT_EQ(message->data()["scan_time"].as<float>(), 0.0);
+      ASSERT_EQ(message->data()["header"]["seq"]->as<uint32_t>(), scan_seq++);
+      ASSERT_EQ(message->data()["header"]["frame_id"]->as<std::string>(), "base_laser_link");
+      ASSERT_EQ(message->data()["scan_time"]->as<float>(), 0.0);
 
       // Arrays are exposed at blobs
-      ASSERT_EQ(message->data()["ranges"].getType(), Embag::RosValue::Type::array);
+      ASSERT_EQ(message->data()["ranges"]->getType(), Embag::RosValue::Type::array);
       const auto array = message->data()["ranges"];
-      ASSERT_EQ(array[0].getType(), Embag::RosValue::Type::float32);
-      ASSERT_EQ(array.size(), 90);
+      ASSERT_EQ(array[0]->getType(), Embag::RosValue::Type::float32);
+      ASSERT_EQ(array->size(), 90);
 
-      for (size_t i = 0; i < array.size(); ++i) {
-        ASSERT_NE(array[i].as<float>(), 0.0);
+      for (size_t i = 0; i < array->size(); ++i) {
+        ASSERT_NE(array[i]->as<float>(), 0.0);
       }
     }
 
@@ -192,15 +192,15 @@ TEST_F(ViewTest, AllMessages) {
       ASSERT_GE(message->timestamp.to_sec(), last_pose_ts);
       last_pose_ts = message->timestamp.to_sec();
       ASSERT_EQ(message->md5, "cd5e73d190d741a2f92e81eda573aca7");
-      ASSERT_EQ(message->data()["header"]["seq"].as<uint32_t>(), pose_seq++);
-      ASSERT_EQ(message->data()["header"]["frame_id"].as<std::string>(), "odom");
-      ASSERT_NE(message->data()["pose"]["pose"]["position"]["x"].as<double>(), 0.0);
+      ASSERT_EQ(message->data()["header"]["seq"]->as<uint32_t>(), pose_seq++);
+      ASSERT_EQ(message->data()["header"]["frame_id"]->as<std::string>(), "odom");
+      ASSERT_NE(message->data()["pose"]["pose"]["position"]["x"]->as<double>(), 0.0);
 
-      ASSERT_EQ(message->data()["pose"]["covariance"].getType(), Embag::RosValue::Type::array);
+      ASSERT_EQ(message->data()["pose"]["covariance"]->getType(), Embag::RosValue::Type::array);
       const auto array = message->data()["pose"]["covariance"];
 
-      for (size_t i = 0; i < array.size(); i++) {
-        ASSERT_EQ(array[i].as<float>(), 0.0);
+      for (size_t i = 0; i < array->size(); i++) {
+        ASSERT_EQ(array[i]->as<float>(), 0.0);
       }
     }
   }


### PR DESCRIPTION
Fixes: DATA-526

Description of Changes
======================
There was a memory leak resulting from the recent performance changes due to circular `shared_ptr`s. This fixes the issue by storing `weak_ptr`s to the `vector` of `RosValue`s and then having any interfaces that access the `RosValue`s `lock` the `weak_ptr` and return a `RosValuePointer` which stores the locked `weak_ptr` (which is just a `shared_ptr`).

Test Plan
=========
Tests + ensured that `-fsanitize=address` does not show any errors.
