### PR TITLE
Return ROS time values

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ http_archive(
 http_archive(
     name = "pybind11",
     build_file = "@pybind11_bazel//:pybind11.BUILD",
-    sha256 = "97504db65640570f32d3fdf701c25a340c8643037c3b69aec469c10c93dc8504",
-    strip_prefix = "pybind11-2.5.0",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz"],
+    sha256 = "c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913",
+    strip_prefix = "pybind11-2.9.1",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"],
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -49,7 +49,10 @@ class RosValue {
   static size_t primitiveTypeToSize(const Type type);
   static std::string primitiveTypeToFormat(const Type type);
 
-  struct ros_time_t {
+ private:
+  template<class ChildType>
+  class TimeValue {
+   public:
     uint32_t secs = 0;
     uint32_t nsecs = 0;
 
@@ -61,32 +64,41 @@ class RosValue {
       return long(secs) * long(1e9) + long(nsecs);
     }
 
-    ros_time_t() {};
-    ros_time_t(const uint32_t secs, const uint32_t nsecs) : secs(secs), nsecs(nsecs) {}
+    TimeValue() {};
+    TimeValue(const uint32_t secs, const uint32_t nsecs) : secs(secs), nsecs(nsecs) {}
 
-    bool operator==(const ros_time_t &other) const {
+    bool operator==(const ChildType &other) const {
       return secs == other.secs && nsecs == other.nsecs;
+    }
+
+    bool operator!=(const ChildType &other) const {
+      return secs != other.secs || nsecs != other.nsecs;
+    }
+
+    bool operator<(const ChildType &other) const {
+      return secs < other.secs || (secs == other.secs && nsecs < other.nsecs);
+    }
+
+    bool operator<=(const ChildType &other) const {
+      return secs < other.secs || (secs == other.secs && nsecs <= other.nsecs);
+    }
+
+    bool operator>(const ChildType &other) const {
+      return secs > other.secs || (secs == other.secs && nsecs > other.nsecs);
+    }
+
+    bool operator>=(const ChildType &other) const {
+      return secs > other.secs || (secs == other.secs && nsecs >= other.nsecs);
     }
   };
 
-  struct ros_duration_t {
-    int32_t secs = 0;
-    int32_t nsecs = 0;
+ public:
+  class ros_time_t : public TimeValue<ros_time_t> {
+    using TimeValue<ros_time_t>::TimeValue;
+  };
 
-    double to_sec() const {
-      return double(secs) + double(nsecs) / 1e9;
-    }
-
-    long to_nsec() const {
-      return long(secs) * long(1e9) + long(nsecs);
-    }
-
-    ros_duration_t() {};
-    ros_duration_t(const uint32_t secs, const uint32_t nsecs) : secs(secs), nsecs(nsecs) {}
-
-    bool operator==(const ros_duration_t &other) const {
-      return secs == other.secs && nsecs == other.nsecs;
-    }
+  struct ros_duration_t : public TimeValue<ros_duration_t> {
+    using TimeValue<ros_duration_t>::TimeValue;
   };
 
   Type getType() const {

--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,6 @@ bag.close()
 Unfortunately, this API comes with a few caveats:
 - It's slightly slower than the second, more native API.
 - You can't iterate over more than one bag file (something ROS's C++ API allows you to do).
-- Special ROS primitives (such as `Time` and `Duration`) haven't been built out yet.  For now, these values are provided as doubles.
 
 Embag also offers an API more like the [C++ API](http://wiki.ros.org/rosbag/Code%20API#C.2B-.2B-_API):
 ```python

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -184,9 +184,9 @@ py::object castValue(const Embag::RosValue::Pointer& value) {
       return encodeStrLatin1(value->as<std::string>());
     // TODO: Don't return floats here - the raw ros time has more precision
     case Embag::RosValue::Type::ros_time:
-      return py::cast(value->as<Embag::RosValue::ros_time_t>().to_sec());
+      return py::cast(value->as<Embag::RosValue::ros_time_t>());
     case Embag::RosValue::Type::ros_duration:
-      return py::cast(value->as<Embag::RosValue::ros_duration_t>().to_sec());
+      return py::cast(value->as<Embag::RosValue::ros_duration_t>());
     default:
       throw std::runtime_error("Unhandled type");
   }

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -21,9 +21,15 @@ typedef std::unordered_set<Embag::RosValue::Type, EnumClassHash> RosValueTypeSet
 typedef std::unordered_set<Embag::RosValue::Type> RosValueTypeSet;
 #endif
 
-py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type);
-py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type);
-py::object castValue(const Embag::RosValue::Pointer &value, py::object ros_time_py_type);
+py::dict rosValueToDict(
+  const Embag::RosValue::Pointer &ros_value,
+  const RosValueTypeSet &types_to_unpack,
+  const py::object& ros_time_py_type);
+py::list rosValueToList(
+  const Embag::RosValue::Pointer &ros_value,
+  const RosValueTypeSet &types_to_unpack,
+  const py::object& ros_time_py_type);
+py::object castValue(const Embag::RosValue::Pointer &value, const py::object& ros_time_py_type);
 
 // By default, it doesn't make sense to return a memoryview for python non-primitive types
 const RosValueTypeSet default_types_to_unpack = {
@@ -31,7 +37,10 @@ const RosValueTypeSet default_types_to_unpack = {
   Embag::RosValue::Type::ros_time
 };
 
-py::object primitiveArrayToPyObject(const Embag::RosValue::Pointer &primitive_array, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
+py::object primitiveArrayToPyObject(
+    const Embag::RosValue::Pointer &primitive_array,
+    const RosValueTypeSet &types_to_unpack=default_types_to_unpack,
+    const py::object& ros_time_py_type=py::none()) {
   const Embag::RosValue::Type item_type = primitive_array->getElementType();
 
   if (types_to_unpack.find(item_type) != types_to_unpack.end()) {
@@ -47,7 +56,10 @@ py::object primitiveArrayToPyObject(const Embag::RosValue::Pointer &primitive_ar
   }
 }
 
-py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
+py::list rosValueToList(
+    const Embag::RosValue::Pointer &ros_value,
+    const RosValueTypeSet &types_to_unpack=default_types_to_unpack,
+    const py::object& ros_time_py_type=py::none()) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::array && ros_value->getType() != Type::primitive_array) {
@@ -98,7 +110,10 @@ py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValu
   return list;
 }
 
-py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
+py::dict rosValueToDict(
+    const Embag::RosValue::Pointer &ros_value,
+    const RosValueTypeSet &types_to_unpack=default_types_to_unpack,
+    const py::object& ros_time_py_type=py::none()) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::object) {
@@ -153,7 +168,7 @@ py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValu
 }
 
 template<typename RosTimeType>
-py::object castRosTime(const Embag::RosValue::Pointer& ros_value, py::object py_type=py::none()) {
+py::object castRosTime(const Embag::RosValue::Pointer& ros_value, const py::object& py_type=py::none()) {
   const RosTimeType time_value = ros_value->as<RosTimeType>();
   if (py_type.is_none()) {
     // Keep as a RosTime or RosDuration
@@ -179,7 +194,7 @@ py::object castRosTime(const Embag::RosValue::Pointer& ros_value, py::object py_
   }
 }
 
-py::object castValue(const Embag::RosValue::Pointer& value, py::object ros_time_py_type=py::none()) {
+py::object castValue(const Embag::RosValue::Pointer& value, const py::object& ros_time_py_type=py::none()) {
   switch (value->getType()) {
     case Embag::RosValue::Type::object:
     case Embag::RosValue::Type::array:

--- a/python/adapters.h
+++ b/python/adapters.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 
 #include "utils.h"
 
@@ -21,9 +21,9 @@ typedef std::unordered_set<Embag::RosValue::Type, EnumClassHash> RosValueTypeSet
 typedef std::unordered_set<Embag::RosValue::Type> RosValueTypeSet;
 #endif
 
-py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack);
-py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack);
-py::object castValue(const Embag::RosValue::Pointer &value);
+py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type);
+py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type);
+py::object castValue(const Embag::RosValue::Pointer &value, py::object ros_time_py_type);
 
 // By default, it doesn't make sense to return a memoryview for python non-primitive types
 const RosValueTypeSet default_types_to_unpack = {
@@ -31,11 +31,11 @@ const RosValueTypeSet default_types_to_unpack = {
   Embag::RosValue::Type::ros_time
 };
 
-py::object primitiveArrayToPyObject(const Embag::RosValue::Pointer &primitive_array, const RosValueTypeSet &types_to_unpack=default_types_to_unpack) {
+py::object primitiveArrayToPyObject(const Embag::RosValue::Pointer &primitive_array, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
   const Embag::RosValue::Type item_type = primitive_array->getElementType();
 
   if (types_to_unpack.find(item_type) != types_to_unpack.end()) {
-    return rosValueToList(primitive_array, default_types_to_unpack);
+    return rosValueToList(primitive_array, default_types_to_unpack, ros_time_py_type);
   } else {
     #if PY_VERSION_HEX >= 0x03030000
       // In python 3.3 and above, memoryview provides good support for converting to a list via tolist
@@ -47,7 +47,7 @@ py::object primitiveArrayToPyObject(const Embag::RosValue::Pointer &primitive_ar
   }
 }
 
-py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack) {
+py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::array && ros_value->getType() != Type::primitive_array) {
@@ -73,20 +73,20 @@ py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValu
       case Type::string:
       case Type::ros_time:
       case Type::ros_duration: {
-        list.append(castValue(value));
+        list.append(castValue(value, ros_time_py_type));
         break;
       }
       case Type::object: {
-        list.append(rosValueToDict(value, types_to_unpack));
+        list.append(rosValueToDict(value, types_to_unpack, ros_time_py_type));
         break;
       }
       case Type::primitive_array: {
-        list.append(primitiveArrayToPyObject(value, types_to_unpack));
+        list.append(primitiveArrayToPyObject(value, types_to_unpack, ros_time_py_type));
         break;
       }
       case Type::array:
       {
-        list.append(rosValueToList(value, types_to_unpack));
+        list.append(rosValueToList(value, types_to_unpack, ros_time_py_type));
         break;
       }
       default: {
@@ -98,7 +98,7 @@ py::list rosValueToList(const Embag::RosValue::Pointer &ros_value, const RosValu
   return list;
 }
 
-py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack) {
+py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValueTypeSet &types_to_unpack=default_types_to_unpack, py::object ros_time_py_type=py::none()) {
   using Type = Embag::RosValue::Type;
 
   if (ros_value->getType() != Type::object) {
@@ -127,20 +127,20 @@ py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValu
       case Type::string:
       case Type::ros_time:
       case Type::ros_duration: {
-        dict[key] = castValue(value);
+        dict[key] = castValue(value, ros_time_py_type);
         break;
       }
       case Type::object: {
-        dict[key] = rosValueToDict(value, types_to_unpack);
+        dict[key] = rosValueToDict(value, types_to_unpack, ros_time_py_type);
         break;
       }
       case Type::primitive_array: {
-        dict[key] = primitiveArrayToPyObject(value, types_to_unpack);
+        dict[key] = primitiveArrayToPyObject(value, types_to_unpack, ros_time_py_type);
         break;
       }
       case Type::array: 
       {
-        dict[key] = rosValueToList(value, types_to_unpack);
+        dict[key] = rosValueToList(value, types_to_unpack, ros_time_py_type);
         break;
       }
       default: {
@@ -152,7 +152,34 @@ py::dict rosValueToDict(const Embag::RosValue::Pointer &ros_value, const RosValu
   return dict;
 }
 
-py::object castValue(const Embag::RosValue::Pointer& value) {
+template<typename RosTimeType>
+py::object castRosTime(const Embag::RosValue::Pointer& ros_value, py::object py_type=py::none()) {
+  const RosTimeType time_value = ros_value->as<RosTimeType>();
+  if (py_type.is_none()) {
+    // Keep as a RosTime or RosDuration
+    return py::cast(time_value);
+  } else if (!py::isinstance<py::type>(py_type)) {
+    throw py::type_error("Provided python type for casting a ROS time is not a type!");
+  } else {
+    PyObject* native_py_type = py_type.ptr();
+    if (
+      native_py_type == (PyObject*) &PyLong_Type
+      // In python2, we also need to support the PyInt_Type
+      // (In python3, all `int`s are `long`s under the hood)
+      #if PY_VERSION_HEX < 0x03000000
+      || native_py_type == (PyObject*) &PyInt_Type
+      #endif
+    ) {
+      return py::cast(time_value.to_nsec());
+    } else if (native_py_type == (PyObject*) &PyFloat_Type) {
+      return py::cast(time_value.to_sec());
+    } else {
+      throw py::value_error("Can only cast ROS times and durations to int or float!");
+    }
+  }
+}
+
+py::object castValue(const Embag::RosValue::Pointer& value, py::object ros_time_py_type=py::none()) {
   switch (value->getType()) {
     case Embag::RosValue::Type::object:
     case Embag::RosValue::Type::array:
@@ -182,11 +209,10 @@ py::object castValue(const Embag::RosValue::Pointer& value) {
       return py::cast(value->as<double>());
     case Embag::RosValue::Type::string:
       return encodeStrLatin1(value->as<std::string>());
-    // TODO: Don't return floats here - the raw ros time has more precision
     case Embag::RosValue::Type::ros_time:
-      return py::cast(value->as<Embag::RosValue::ros_time_t>());
+      return castRosTime<Embag::RosValue::ros_time_t>(value, ros_time_py_type);
     case Embag::RosValue::Type::ros_duration:
-      return py::cast(value->as<Embag::RosValue::ros_duration_t>());
+      return castRosTime<Embag::RosValue::ros_duration_t>(value, ros_time_py_type);
     default:
       throw std::runtime_error("Unhandled type");
   }

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -77,13 +77,13 @@ PYBIND11_MODULE(libembag, m) {
       .def("data", [](std::shared_ptr<Embag::RosMessage> &m) {
         return m->data();
       })
-      .def("dict", [](std::shared_ptr<Embag::RosMessage> &m, const RosValueTypeSet &types_to_unpack) {
+      .def("dict", [](std::shared_ptr<Embag::RosMessage> &m, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type) {
         if (m->data()->getType() != Embag::RosValue::Type::object) {
           throw std::runtime_error("Element is not an object");
         }
 
-        return rosValueToDict(m->data(), types_to_unpack);
-      }, py::arg("types_to_unpack") = default_types_to_unpack)
+        return rosValueToDict(m->data(), types_to_unpack, ros_time_py_type);
+      }, py::arg("types_to_unpack") = default_types_to_unpack, py::arg("ros_time_py_type") = py::none())
       .def_readonly("topic", &Embag::RosMessage::topic)
       .def_readonly("timestamp", &Embag::RosMessage::timestamp)
       .def_readonly("md5", &Embag::RosMessage::md5)
@@ -118,17 +118,17 @@ PYBIND11_MODULE(libembag, m) {
       .def("__str__", [](Embag::RosValue::Pointer &v, const std::string &path) {
         return encodeStrLatin1(v->toString());
       }, py::arg("path") = "")
-      .def("dict", [](Embag::RosValue::Pointer &v, const RosValueTypeSet &types_to_unpack) {
+      .def("dict", [](Embag::RosValue::Pointer &v, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type) {
         if (v->getType() == Embag::RosValue::Type::object) {
-          return (py::object) rosValueToDict(v, types_to_unpack);
+          return (py::object) rosValueToDict(v, types_to_unpack, ros_time_py_type);
         } else if (v->getType() == Embag::RosValue::Type::array) {
-          return (py::object) rosValueToList(v, types_to_unpack);
+          return (py::object) rosValueToList(v, types_to_unpack, ros_time_py_type);
         } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
-          return (py::object) primitiveArrayToPyObject(v, types_to_unpack);
+          return (py::object) primitiveArrayToPyObject(v, types_to_unpack, ros_time_py_type);
         } else {
           throw std::runtime_error("Somehow you have a RosValue whose type is primitive");
         }
-      }, py::arg("types_to_unpack") = default_types_to_unpack)
+      }, py::arg("types_to_unpack") = default_types_to_unpack, py::arg("ros_time_py_type") = py::none())
       .def("__iter__", [](Embag::RosValue::Pointer &v) {
         switch (v->getType()) {
           case Embag::RosValue::Type::array:

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -174,6 +174,7 @@ PYBIND11_MODULE(libembag, m) {
       .def_readonly("secs", &Embag::RosValue::ros_time_t::secs)
       .def_readonly("nsecs", &Embag::RosValue::ros_time_t::nsecs)
       .def("to_sec", &Embag::RosValue::ros_time_t::to_sec)
+      .def("to_nsec", &Embag::RosValue::ros_time_t::to_nsec)
       .def("__str__", [](Embag::RosValue::ros_time_t &v) {
         return std::to_string(v.to_nsec());
       });
@@ -181,6 +182,8 @@ PYBIND11_MODULE(libembag, m) {
   py::class_<Embag::RosValue::ros_duration_t>(m, "RosDuration")
       .def_readonly("secs", &Embag::RosValue::ros_duration_t::secs)
       .def_readonly("nsecs", &Embag::RosValue::ros_duration_t::nsecs)
+      .def("to_sec", &Embag::RosValue::ros_duration_t::to_sec)
+      .def("to_nsec", &Embag::RosValue::ros_duration_t::to_nsec)
       .def("__str__", [](Embag::RosValue::ros_duration_t &v) {
         return std::to_string(v.to_nsec());
       });

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -171,19 +171,35 @@ PYBIND11_MODULE(libembag, m) {
       });
 
   py::class_<Embag::RosValue::ros_time_t>(m, "RosTime")
+      .def(py::init())
+      .def(py::init<uint32_t, uint32_t>())
       .def_readonly("secs", &Embag::RosValue::ros_time_t::secs)
       .def_readonly("nsecs", &Embag::RosValue::ros_time_t::nsecs)
       .def("to_sec", &Embag::RosValue::ros_time_t::to_sec)
       .def("to_nsec", &Embag::RosValue::ros_time_t::to_nsec)
+      .def("__eq__", &Embag::RosValue::ros_time_t::operator==)
+      .def("__ne__", &Embag::RosValue::ros_time_t::operator!=)
+      .def("__lt__", &Embag::RosValue::ros_time_t::operator<)
+      .def("__le__", &Embag::RosValue::ros_time_t::operator<=)
+      .def("__gt__", &Embag::RosValue::ros_time_t::operator>)
+      .def("__ge__", &Embag::RosValue::ros_time_t::operator>=)
       .def("__str__", [](Embag::RosValue::ros_time_t &v) {
         return std::to_string(v.to_nsec());
       });
 
   py::class_<Embag::RosValue::ros_duration_t>(m, "RosDuration")
+      .def(py::init())
+      .def(py::init<uint32_t, uint32_t>())
       .def_readonly("secs", &Embag::RosValue::ros_duration_t::secs)
       .def_readonly("nsecs", &Embag::RosValue::ros_duration_t::nsecs)
       .def("to_sec", &Embag::RosValue::ros_duration_t::to_sec)
       .def("to_nsec", &Embag::RosValue::ros_duration_t::to_nsec)
+      .def("__eq__", &Embag::RosValue::ros_duration_t::operator==)
+      .def("__ne__", &Embag::RosValue::ros_duration_t::operator!=)
+      .def("__lt__", &Embag::RosValue::ros_duration_t::operator<)
+      .def("__le__", &Embag::RosValue::ros_duration_t::operator<=)
+      .def("__gt__", &Embag::RosValue::ros_duration_t::operator>)
+      .def("__ge__", &Embag::RosValue::ros_duration_t::operator>=)
       .def("__str__", [](Embag::RosValue::ros_duration_t &v) {
         return std::to_string(v.to_nsec());
       });

--- a/python/ros_compat.h
+++ b/python/ros_compat.h
@@ -15,8 +15,7 @@ struct IteratorCompat {
     return py::make_tuple(
       msg->topic,
       msg->data(),
-      // TODO: Change the timestamp to a rostime - they have more precision!
-      msg->timestamp.to_sec()
+      msg->timestamp
     );
   }
 

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -81,7 +81,7 @@ class EmbagTest(unittest.TestCase):
         for topic, msg, t in self.bag.read_messages(topics=list(self.known_topics)):
             self.assertTrue(topic in self.known_topics)
             self.assertNotEqual(topic, "")
-            self.assertGreater(t, 0)
+            self.assertGreater(t.to_sec(), 0)
 
             if topic in unseen_topics:
                 unseen_topics.remove(topic)
@@ -223,6 +223,13 @@ class EmbagTest(unittest.TestCase):
                 message_dict['data'],
                 msg.data()['data'].dict(),
             )
+
+    def testROSTimeDicting(self):
+        for msg in self.view.getMessages('/base_pose_ground_truth'):
+            assert isinstance(msg.dict()['header']['stamp'], embag.RosTime)
+            assert isinstance(msg.dict(ros_time_py_type=None)['header']['stamp'], embag.RosTime)
+            assert isinstance(msg.dict(ros_time_py_type=int)['header']['stamp'], int)
+            assert isinstance(msg.dict(ros_time_py_type=float)['header']['stamp'], float)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -227,9 +227,14 @@ class EmbagTest(unittest.TestCase):
     def testROSTimeDicting(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
             assert isinstance(msg.dict()['header']['stamp'], embag.RosTime)
-            assert isinstance(msg.dict(ros_time_py_type=None)['header']['stamp'], embag.RosTime)
-            assert isinstance(msg.dict(ros_time_py_type=int)['header']['stamp'], int)
-            assert isinstance(msg.dict(ros_time_py_type=float)['header']['stamp'], float)
+            as_ros_time = msg.dict(ros_time_py_type=None)['header']['stamp']
+            as_int = msg.dict(ros_time_py_type=int)['header']['stamp']
+            as_float = msg.dict(ros_time_py_type=float)['header']['stamp']
+            assert isinstance(as_ros_time, embag.RosTime)
+            assert isinstance(as_int, int)
+            assert isinstance(as_float, float)
+            assert as_ros_time.to_nsec() == as_int
+            assert as_ros_time.to_sec() == as_float
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes: DATA-627

Description of Changes
======================
This switches the python interface to providing timestamps as ROS times, similar to how the actual rospy interface works.

Test Plan
=========
Unit tests.
