### PR TITLE
Add dict method for RosValues

### DIFF
--- a/python/embag.cc
+++ b/python/embag.cc
@@ -126,7 +126,7 @@ PYBIND11_MODULE(libembag, m) {
         } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
           return (py::object) primitiveArrayToPyObject(v, types_to_unpack);
         } else {
-          throw std::runtime_error("Somehow you have a RosValue who's type is primitive");
+          throw std::runtime_error("Somehow you have a RosValue whose type is primitive");
         }
       }, py::arg("types_to_unpack") = default_types_to_unpack)
       .def("__iter__", [](Embag::RosValue::Pointer &v) {

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -77,7 +77,7 @@ PYBIND11_MODULE(libembag, m) {
       .def("data", [](std::shared_ptr<Embag::RosMessage> &m) {
         return m->data();
       })
-      .def("dict", [](std::shared_ptr<Embag::RosMessage> &m, const RosValueTypeSet &types_to_unpack=default_types_to_unpack) {
+      .def("dict", [](std::shared_ptr<Embag::RosMessage> &m, const RosValueTypeSet &types_to_unpack) {
         if (m->data()->getType() != Embag::RosValue::Type::object) {
           throw std::runtime_error("Element is not an object");
         }
@@ -118,6 +118,17 @@ PYBIND11_MODULE(libembag, m) {
       .def("__str__", [](Embag::RosValue::Pointer &v, const std::string &path) {
         return encodeStrLatin1(v->toString());
       }, py::arg("path") = "")
+      .def("dict", [](Embag::RosValue::Pointer &v, const RosValueTypeSet &types_to_unpack) {
+        if (v->getType() == Embag::RosValue::Type::object) {
+          return (py::object) rosValueToDict(v, types_to_unpack);
+        } else if (v->getType() == Embag::RosValue::Type::array) {
+          return (py::object) rosValueToList(v, types_to_unpack);
+        } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
+          return (py::object) primitiveArrayToPyObject(v, types_to_unpack);
+        } else {
+          throw std::runtime_error("Somehow you have a RosValue who's type is primitive");
+        }
+      }, py::arg("types_to_unpack") = default_types_to_unpack)
       .def("__iter__", [](Embag::RosValue::Pointer &v) {
         switch (v->getType()) {
           case Embag::RosValue::Type::array:

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -190,7 +190,7 @@ class EmbagTest(unittest.TestCase):
             for covariance in np.array(covariance_array, copy=False):
                 self.assertEqual(covariance, 0)
 
-    def testToDictMemoryView(self):
+    def testDictMemoryView(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
             dict_list = msg.dict()['pose']['covariance'].tolist()
             data_list = [v for v in msg.data()['pose']['covariance']]
@@ -200,6 +200,29 @@ class EmbagTest(unittest.TestCase):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
             assert isinstance(msg.dict()['pose']['covariance'], memoryview if sys.version_info >= (3,3) else np.ndarray)
             assert isinstance(msg.dict(types_to_unpack={embag.RosValueType.float64})['pose']['covariance'], list)
+
+    def testRosValueDict(self):
+        # Validate that dict on RosValue functions the same as on messages
+        for msg in self.view.getMessages('/luminar_pointcloud'):
+            message_dict = msg.dict()
+            # Below python3.3, primitive arrays in dict form are numpy arrays
+            # so we need to compare them with numpy's utilities.
+            # This comparison still works in python3.3 and above, so just use it no matter what
+            # Test RosValue objects
+            np.testing.assert_equal(
+                message_dict['header'],
+                msg.data()['header'].dict(),
+            )
+            # Test RosValue arrays
+            np.testing.assert_equal(
+                message_dict['fields'],
+                msg.data()['fields'].dict(),
+            )
+            # Test RosValue primitive_arrays
+            np.testing.assert_equal(
+                message_dict['data'],
+                msg.data()['data'].dict(),
+            )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes: DATA-604

Description of Changes
======================
Adds the `dict` method present on `RosMessage`s to also exist on `RosValue`s.

Test Plan
=========
Added a unit test.
