### PR TITLE
Default to bytes in dict() serialization

### DIFF
--- a/lib/ros_value.cc
+++ b/lib/ros_value.cc
@@ -47,6 +47,14 @@ const void* RosValue::getPrimitiveArrayRosValueBuffer() const {
   return static_cast<const void *>(&at(0)->getPrimitive<uint8_t>());
 }
 
+size_t RosValue::getPrimitiveArrayRosValueBufferSize() const {
+  if (getType() != Embag::RosValue::Type::primitive_array) {
+    throw std::runtime_error("Cannot access the buffer of a non primitive_array RosValue");
+  }
+
+  return primitive_array_info_.length * primitiveTypeToSize(getElementType());
+}
+
 template<typename T>
 const T &RosValue::getValue(const std::string &key) const {
   return get(key)->as<T>();

--- a/lib/ros_value.h
+++ b/lib/ros_value.h
@@ -326,6 +326,7 @@ class RosValue {
   // The life of the buffer is only guaranteed to live as long as the RosValuePointer does,
   // and as a result this should be used with great caution.
   const void* getPrimitiveArrayRosValueBuffer() const;
+  size_t getPrimitiveArrayRosValueBufferSize() const;
 
   std::unordered_map<std::string, Pointer> getObjects() const;
   std::vector<Pointer> getValues() const;

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -77,13 +77,22 @@ PYBIND11_MODULE(libembag, m) {
       .def("data", [](std::shared_ptr<Embag::RosMessage> &m) {
         return m->data();
       })
-      .def("dict", [](std::shared_ptr<Embag::RosMessage> &m, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type) {
-        if (m->data()->getType() != Embag::RosValue::Type::object) {
-          throw std::runtime_error("Element is not an object");
-        }
+      .def(
+        "dict",
+        [](
+            std::shared_ptr<Embag::RosMessage> &m,
+            const RosValueTypeSet &types_to_unpack,
+            bool packed_types_as_memoryview,
+            py::object ros_time_py_type) {
+          if (m->data()->getType() != Embag::RosValue::Type::object) {
+            throw std::runtime_error("Element is not an object");
+          }
 
-        return rosValueToDict(m->data(), types_to_unpack, ros_time_py_type);
-      }, py::arg("types_to_unpack") = default_types_to_unpack, py::arg("ros_time_py_type") = py::none())
+          return rosValueToDict(m->data(), types_to_unpack, packed_types_as_memoryview, ros_time_py_type);
+        },
+        py::arg("types_to_unpack") = default_types_to_unpack,
+        py::arg("packed_types_as_memoryview") = false,
+        py::arg("ros_time_py_type") = py::none())
       .def_readonly("topic", &Embag::RosMessage::topic)
       .def_readonly("timestamp", &Embag::RosMessage::timestamp)
       .def_readonly("md5", &Embag::RosMessage::md5)
@@ -118,17 +127,36 @@ PYBIND11_MODULE(libembag, m) {
       .def("__str__", [](Embag::RosValue::Pointer &v, const std::string &path) {
         return encodeStrLatin1(v->toString());
       }, py::arg("path") = "")
-      .def("dict", [](Embag::RosValue::Pointer &v, const RosValueTypeSet &types_to_unpack, py::object ros_time_py_type) {
-        if (v->getType() == Embag::RosValue::Type::object) {
-          return (py::object) rosValueToDict(v, types_to_unpack, ros_time_py_type);
-        } else if (v->getType() == Embag::RosValue::Type::array) {
-          return (py::object) rosValueToList(v, types_to_unpack, ros_time_py_type);
-        } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
-          return (py::object) primitiveArrayToPyObject(v, types_to_unpack, ros_time_py_type);
-        } else {
-          throw std::runtime_error("Somehow you have a RosValue whose type is primitive");
-        }
-      }, py::arg("types_to_unpack") = default_types_to_unpack, py::arg("ros_time_py_type") = py::none())
+      .def(
+        "dict",
+        [](
+            Embag::RosValue::Pointer &v,
+            const RosValueTypeSet &types_to_unpack,
+            bool packed_types_as_memoryview,
+            py::object ros_time_py_type) {
+          if (v->getType() == Embag::RosValue::Type::object) {
+            return (py::object) rosValueToDict(
+              v,
+              types_to_unpack,
+              packed_types_as_memoryview,
+              ros_time_py_type);
+          } else if (v->getType() == Embag::RosValue::Type::array) {
+            return (py::object) rosValueToList(v,
+              types_to_unpack,
+              packed_types_as_memoryview,
+              ros_time_py_type);
+          } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
+            return (py::object) primitiveArrayToPyObject(v,
+              types_to_unpack,
+              packed_types_as_memoryview,
+              ros_time_py_type);
+          } else {
+            throw std::runtime_error("Somehow you have a RosValue whose type is primitive");
+          }
+        },
+        py::arg("types_to_unpack") = default_types_to_unpack,
+        py::arg("packed_types_as_memoryview") = false,
+        py::arg("ros_time_py_type") = py::none())
       .def("__iter__", [](Embag::RosValue::Pointer &v) {
         switch (v->getType()) {
           case Embag::RosValue::Type::array:

--- a/python/embag.cc
+++ b/python/embag.cc
@@ -81,17 +81,17 @@ PYBIND11_MODULE(libembag, m) {
         "dict",
         [](
             std::shared_ptr<Embag::RosMessage> &m,
-            const RosValueTypeSet &types_to_unpack,
-            bool packed_types_as_memoryview,
+            const RosValueTypeSet &array_blob_types,
+            bool blob_types_as_memoryview,
             py::object ros_time_py_type) {
           if (m->data()->getType() != Embag::RosValue::Type::object) {
             throw std::runtime_error("Element is not an object");
           }
 
-          return rosValueToDict(m->data(), types_to_unpack, packed_types_as_memoryview, ros_time_py_type);
+          return rosValueToDict(m->data(), array_blob_types, blob_types_as_memoryview, ros_time_py_type);
         },
-        py::arg("types_to_unpack") = default_types_to_unpack,
-        py::arg("packed_types_as_memoryview") = false,
+        py::arg("array_blob_types") = default_array_blob_types,
+        py::arg("blob_types_as_memoryview") = false,
         py::arg("ros_time_py_type") = py::none())
       .def_readonly("topic", &Embag::RosMessage::topic)
       .def_readonly("timestamp", &Embag::RosMessage::timestamp)
@@ -131,31 +131,31 @@ PYBIND11_MODULE(libembag, m) {
         "dict",
         [](
             Embag::RosValue::Pointer &v,
-            const RosValueTypeSet &types_to_unpack,
-            bool packed_types_as_memoryview,
+            const RosValueTypeSet &array_blob_types,
+            bool blob_types_as_memoryview,
             py::object ros_time_py_type) {
           if (v->getType() == Embag::RosValue::Type::object) {
             return (py::object) rosValueToDict(
               v,
-              types_to_unpack,
-              packed_types_as_memoryview,
+              array_blob_types,
+              blob_types_as_memoryview,
               ros_time_py_type);
           } else if (v->getType() == Embag::RosValue::Type::array) {
             return (py::object) rosValueToList(v,
-              types_to_unpack,
-              packed_types_as_memoryview,
+              array_blob_types,
+              blob_types_as_memoryview,
               ros_time_py_type);
           } else if (v->getType() == Embag::RosValue::Type::primitive_array) {
             return (py::object) primitiveArrayToPyObject(v,
-              types_to_unpack,
-              packed_types_as_memoryview,
+              array_blob_types,
+              blob_types_as_memoryview,
               ros_time_py_type);
           } else {
             throw std::runtime_error("Somehow you have a RosValue whose type is primitive");
           }
         },
-        py::arg("types_to_unpack") = default_types_to_unpack,
-        py::arg("packed_types_as_memoryview") = false,
+        py::arg("array_blob_types") = default_array_blob_types,
+        py::arg("blob_types_as_memoryview") = false,
         py::arg("ros_time_py_type") = py::none())
       .def("__iter__", [](Embag::RosValue::Pointer &v) {
         switch (v->getType()) {

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -133,7 +133,7 @@ class EmbagTest(unittest.TestCase):
             self.assertGreater(msg.timestamp.to_sec(), 0)
 
             if msg.topic == '/base_scan':
-                msg_dict = msg.dict()
+                msg_dict = msg.dict(types_to_unpack={embag.RosValueType.float32})
                 self.assertEqual(msg_dict['header']['seq'], base_scan_seq)
                 base_scan_seq += 1
                 self.assertEqual(msg_dict['header']['frame_id'], "base_laser_link")
@@ -194,6 +194,8 @@ class EmbagTest(unittest.TestCase):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
             dict_memoryview = msg.dict(packed_types_as_memoryview=True)['pose']['covariance']
             assert isinstance(dict_memoryview, memoryview if sys.version_info >= (3,3) else np.ndarray)
+            dict_bytes = msg.dict()['pose']['covariance']
+            assert bytes(bytearray(dict_memoryview)) == dict_bytes
             dict_list = dict_memoryview.tolist()
             data_list = [v for v in msg.data()['pose']['covariance']]
             assert dict_list == data_list

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -196,7 +196,7 @@ class EmbagTest(unittest.TestCase):
             assert isinstance(dict_memoryview, memoryview if sys.version_info >= (3,3) else np.ndarray)
             dict_list = dict_memoryview.tolist()
             data_list = [v for v in msg.data()['pose']['covariance']]
-            assert len(dict_list) == len(data_list)
+            assert dict_list == data_list
 
     def testDictUnpacking(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -133,7 +133,7 @@ class EmbagTest(unittest.TestCase):
             self.assertGreater(msg.timestamp.to_sec(), 0)
 
             if msg.topic == '/base_scan':
-                msg_dict = msg.dict(types_to_unpack={embag.RosValueType.float32})
+                msg_dict = msg.dict()
                 self.assertEqual(msg_dict['header']['seq'], base_scan_seq)
                 base_scan_seq += 1
                 self.assertEqual(msg_dict['header']['frame_id'], "base_laser_link")
@@ -192,9 +192,12 @@ class EmbagTest(unittest.TestCase):
 
     def testDictMemoryView(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
-            dict_memoryview = msg.dict(packed_types_as_memoryview=True)['pose']['covariance']
+            dict_memoryview = msg.dict(
+                array_blob_types={embag.RosValueType.float64},
+                blob_types_as_memoryview=True,
+            )['pose']['covariance']
             assert isinstance(dict_memoryview, memoryview if sys.version_info >= (3,3) else np.ndarray)
-            dict_bytes = msg.dict()['pose']['covariance']
+            dict_bytes = msg.dict(array_blob_types={embag.RosValueType.float64})['pose']['covariance']
             assert bytes(bytearray(dict_memoryview)) == dict_bytes
             dict_list = dict_memoryview.tolist()
             data_list = [v for v in msg.data()['pose']['covariance']]
@@ -202,8 +205,8 @@ class EmbagTest(unittest.TestCase):
 
     def testDictUnpacking(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
-            assert isinstance(msg.dict()['pose']['covariance'], bytes)
-            assert isinstance(msg.dict(types_to_unpack={embag.RosValueType.float64})['pose']['covariance'], list)
+            assert isinstance(msg.dict(array_blob_types={embag.RosValueType.float64})['pose']['covariance'], bytes)
+            assert isinstance(msg.dict()['pose']['covariance'], list)
 
     def testRosValueDict(self):
         # Validate that dict on RosValue functions the same as on messages

--- a/test/embag_test_python.py
+++ b/test/embag_test_python.py
@@ -192,13 +192,15 @@ class EmbagTest(unittest.TestCase):
 
     def testDictMemoryView(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
-            dict_list = msg.dict()['pose']['covariance'].tolist()
+            dict_memoryview = msg.dict(packed_types_as_memoryview=True)['pose']['covariance']
+            assert isinstance(dict_memoryview, memoryview if sys.version_info >= (3,3) else np.ndarray)
+            dict_list = dict_memoryview.tolist()
             data_list = [v for v in msg.data()['pose']['covariance']]
-            assert dict_list == data_list
+            assert len(dict_list) == len(data_list)
 
     def testDictUnpacking(self):
         for msg in self.view.getMessages('/base_pose_ground_truth'):
-            assert isinstance(msg.dict()['pose']['covariance'], memoryview if sys.version_info >= (3,3) else np.ndarray)
+            assert isinstance(msg.dict()['pose']['covariance'], bytes)
             assert isinstance(msg.dict(types_to_unpack={embag.RosValueType.float64})['pose']['covariance'], list)
 
     def testRosValueDict(self):


### PR DESCRIPTION
Description of Changes
======================
`memoryview`s are nice, but they don't really make alot of sense in `dict()` which is typically used for serialization. Maintains support for `memorview`s in the `dict` method, but defaults to returning a bytes object.

Test Plan
=========
Python tests
