### PR TITLE
Access to all pybind from root package

### DIFF
--- a/pip_package/embag/__init__.py
+++ b/pip_package/embag/__init__.py
@@ -1,1 +1,1 @@
-from embag.libembag import View, Bag
+from embag.libembag import *


### PR DESCRIPTION
Description of Changes
======================
This makes it so everything exported by pybind is accessible from the root python module.

Test Plan
=========
Built, installed, and verified everything was importable.
