### PR TITLE
Expose the underlying raw data buffer for RosMessage

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -12,7 +12,6 @@ pybind_library(
         "view.cc",
     ],
     hdrs = [
-        -- "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",
@@ -53,7 +52,6 @@ pkg_tar(
 pkg_tar(
     name = "embag-headers",
     srcs = [
-        -- "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -12,6 +12,7 @@ pybind_library(
         "view.cc",
     ],
     hdrs = [
+        "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",
@@ -52,6 +53,7 @@ pkg_tar(
 pkg_tar(
     name = "embag-headers",
     srcs = [
+        "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -12,7 +12,7 @@ pybind_library(
         "view.cc",
     ],
     hdrs = [
-        "ros_serialization.h",
+        -- "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",
@@ -53,7 +53,7 @@ pkg_tar(
 pkg_tar(
     name = "embag-headers",
     srcs = [
-        "ros_serialization.h",
+        -- "ros_serialization.h",
         "decompression.h",
         "embag.h",
         "message_def_parser.h",

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -37,7 +37,10 @@ class RosMessage {
   {
   }
 
-  RosMessageRawBufferData raw_data() const {
+  RosMessageRawBufferData raw_data() {
+    if (!parsed_) {
+      hydrate();
+    }
     const std::vector<char> raw_buffer_ = *raw_buffer; 
     return RosMessageRawBufferData(raw_buffer_, raw_buffer_offset, raw_data_len); 
   } 

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-
+#include "ros_serialization.h"
 #include "ros_value.h"
 #include "message_parser.h"
 #include "ros_msg_types.h"
@@ -37,14 +37,20 @@ class RosMessage {
   {
   }
 
-  RosMessageRawBufferData raw_data() {
+  RosMessageRawBufferData raw_data() const {
     if (!parsed_) {
       hydrate();
     }
     return RosMessageRawBufferData(raw_buffer, raw_buffer_offset, raw_data_len); 
   } 
 
-  const RosValue::Pointer &data() {
+  template<class T>
+  void deserialize_data(T& ros_msg){
+]    ros::serialization::IStream s(reinterpret_cast<uint8_t*>(raw_buffer->at(raw_buffer_offset)), raw_data_len);
+    ros::serialization::deserialize(s, ros_msg);
+  }
+
+  const RosValue::Pointer &data() const {
     if (!parsed_) {
       hydrate();
     }
@@ -52,7 +58,7 @@ class RosMessage {
     return data_;
   }
 
-  bool has(const std::string &key) {
+  bool has(const std::string &key) const {
     if (!parsed_) {
       hydrate();
     }
@@ -60,7 +66,7 @@ class RosMessage {
     return data_->has(key);
   }
 
-  void print() {
+  void print() const {
     if (!parsed_) {
       hydrate();
     }
@@ -68,11 +74,11 @@ class RosMessage {
     data_->print();
   }
 
-  std::string getTypeName(){
+  std::string getTypeName() const {
     return msg_def_->name();
   }
 
-  std::string toString() {
+  std::string toString() const {
     if (!parsed_) {
       hydrate();
     }
@@ -81,11 +87,11 @@ class RosMessage {
   }
 
  private:
-  bool parsed_ = false;
-  RosValue::Pointer data_;
+  mutable bool parsed_ = false;
+  mutable RosValue::Pointer data_;
   std::shared_ptr<RosMsgTypes::MsgDef> msg_def_;
 
-  void hydrate() {
+  void hydrate() const {
     MessageParser msg(raw_buffer, raw_buffer_offset, *msg_def_);
 
     data_ = msg.parse();

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string>
-#include "ros_serialization.h"
+// #include "ros_serialization.h"
+#include <ros/serialization.h>
 #include "ros_value.h"
 #include "message_parser.h"
 #include "ros_msg_types.h"

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -26,7 +26,7 @@ class RosMessage {
   }
 
   template<class T>
-  void deserialize_data(T& ros_msg){
+  void deserialize_data(T& ros_msg) const {
     ros::serialization::IStream s(reinterpret_cast<uint8_t*>(raw_buffer->at(raw_buffer_offset)), raw_data_len);
     ros::serialization::deserialize(s, ros_msg);
   }

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -11,10 +11,10 @@
 namespace Embag {
 
 struct RosMessageRawBufferData { 
-  const std::vector<char> raw_buffer;
+  const std::shared_ptr<std::vector<char>> raw_buffer;
   const size_t raw_buffer_offset;
   const uint32_t raw_data_len = 0;
-  RosMessageRawBufferData(const std::vector<char> raw_buffer_, const size_t raw_buffer_offset_, const uint32_t raw_data_len_)
+  RosMessageRawBufferData(const std::shared_ptr<std::vector<char>> raw_buffer_, const size_t raw_buffer_offset_, const uint32_t raw_data_len_)
     : raw_buffer(raw_buffer_)
     , raw_buffer_offset(raw_buffer_offset_)
     , raw_data_len(raw_data_len_)
@@ -41,8 +41,7 @@ class RosMessage {
     if (!parsed_) {
       hydrate();
     }
-    const std::vector<char> raw_buffer_ = *raw_buffer; 
-    return RosMessageRawBufferData(raw_buffer_, raw_buffer_offset, raw_data_len); 
+    return RosMessageRawBufferData(raw_buffer, raw_buffer_offset, raw_data_len); 
   } 
 
   const RosValue::Pointer &data() {

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -10,18 +10,6 @@
 
 namespace Embag {
 
-struct RosMessageRawBufferData { 
-  const std::shared_ptr<std::vector<char>> raw_buffer;
-  const size_t raw_buffer_offset;
-  const uint32_t raw_data_len = 0;
-  RosMessageRawBufferData(const std::shared_ptr<std::vector<char>> raw_buffer_, const size_t raw_buffer_offset_, const uint32_t raw_data_len_)
-    : raw_buffer(raw_buffer_)
-    , raw_buffer_offset(raw_buffer_offset_)
-    , raw_data_len(raw_data_len_)
-  {
-  }
-}; 
-
 class RosMessage {
  public:
   std::string topic;
@@ -37,16 +25,9 @@ class RosMessage {
   {
   }
 
-  RosMessageRawBufferData raw_data() const {
-    if (!parsed_) {
-      hydrate();
-    }
-    return RosMessageRawBufferData(raw_buffer, raw_buffer_offset, raw_data_len); 
-  } 
-
   template<class T>
   void deserialize_data(T& ros_msg){
-]    ros::serialization::IStream s(reinterpret_cast<uint8_t*>(raw_buffer->at(raw_buffer_offset)), raw_data_len);
+    ros::serialization::IStream s(reinterpret_cast<uint8_t*>(raw_buffer->at(raw_buffer_offset)), raw_data_len);
     ros::serialization::deserialize(s, ros_msg);
   }
 

--- a/lib/ros_message.h
+++ b/lib/ros_message.h
@@ -9,6 +9,19 @@
 #include "util.h"
 
 namespace Embag {
+
+struct RosMessageRawBufferData { 
+  const std::vector<char> raw_buffer;
+  const size_t raw_buffer_offset;
+  const uint32_t raw_data_len = 0;
+  RosMessageRawBufferData(const std::vector<char> raw_buffer_, const size_t raw_buffer_offset_, const uint32_t raw_data_len_)
+    : raw_buffer(raw_buffer_)
+    , raw_buffer_offset(raw_buffer_offset_)
+    , raw_data_len(raw_data_len_)
+  {
+  }
+}; 
+
 class RosMessage {
  public:
   std::string topic;
@@ -23,6 +36,11 @@ class RosMessage {
     , raw_buffer_offset(offset)
   {
   }
+
+  RosMessageRawBufferData raw_data() const {
+    const std::vector<char> raw_buffer_ = *raw_buffer; 
+    return RosMessageRawBufferData(raw_buffer_, raw_buffer_offset, raw_data_len); 
+  } 
 
   const RosValue::Pointer &data() {
     if (!parsed_) {

--- a/lib/ros_serialization.h
+++ b/lib/ros_serialization.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2009, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_SERIALIZATION_H
+#define ROSCPP_SERIALIZATION_H
+
+namespace ros
+{
+namespace serialization
+{
+
+class StreamOverrunException : public std::exception
+{
+  const std::string what_; 
+ public:
+  StreamOverrunException(const std::string& what) : what_(what)
+  {}
+  const char * what () const throw ()
+  {
+    return what_.c_str();
+  }
+};
+	
+void throwStreamOverrun()
+{
+  throw StreamOverrunException("Buffer Overrun");
+}
+
+template<typename T>
+struct Serializer
+{
+  template<typename Stream>
+  inline static void write(Stream& stream, typename boost::call_traits<T>::param_type t)
+  {
+    t.serialize(stream.getData(), 0);
+  }
+
+  template<typename Stream>
+  inline static void read(Stream& stream, typename boost::call_traits<T>::reference t)
+  {
+    t.__serialized_length = stream.getLength();
+    t.deserialize(stream.getData());
+  }
+
+  inline static uint32_t serializedLength(typename boost::call_traits<T>::param_type t)
+  {
+    return t.serializationLength();
+  }
+};
+
+
+template<typename T, typename Stream>
+inline void deserialize(Stream& stream, T& t)
+{
+  Serializer<T>::read(stream, t);
+}
+
+namespace stream_types
+{
+enum StreamType
+{
+  Input,
+  Output,
+  Length
+};
+}
+typedef stream_types::StreamType StreamType;
+
+struct Stream
+{
+  /*
+   * \brief Returns a pointer to the current position of the stream
+   */
+  inline uint8_t* getData() { return data_; }
+  // ROS_FORCE_INLINE uint8_t* advance(uint32_t len)
+  uint8_t* advance(uint32_t len)
+  {
+    uint8_t* old_data = data_;
+    data_ += len;
+    if (data_ > end_)
+    {
+      // Throwing directly here causes a significant speed hit due to the extra code generated
+      // for the throw statement
+      throwStreamOverrun();
+    }
+    return old_data;
+  }
+
+  inline uint32_t getLength() { return (uint32_t)(end_ - data_); }
+
+ protected:
+  Stream(uint8_t* _data, uint32_t _count)
+  : data_(_data)
+  , end_(_data + _count)
+  {}
+
+ private:
+  uint8_t* data_;
+  uint8_t* end_;
+};
+
+struct IStream : public Stream
+{
+  static const StreamType stream_type = stream_types::Input;
+
+  IStream(uint8_t* data, uint32_t count)
+  : Stream(data, count)
+  {}
+
+  template<typename T>
+  void next(T& t)
+  {
+    deserialize(*this, t);
+  }
+
+  template<typename T>
+  IStream& operator>>(T& t)
+  {
+    deserialize(*this, t);
+    return *this;
+  }
+};
+
+} // namespace serialization
+} // namespace ros
+
+#endif // ROSCPP_SERIALIZATION_H


### PR DESCRIPTION
Fixes: SIM-274

Description of Changes
======================
Exposing raw data buffer for more complex, serialized message fields. 

Test Plan
=========
Able to build simulation, but cannot fully test by running simulation until the RosValuePointer also has its raw data exposed. 