### PR TITLE
Re-add ability to pass topics as tuple

### DIFF
--- a/python/embag.cc
+++ b/python/embag.cc
@@ -28,10 +28,8 @@ PYBIND11_MODULE(libembag, m) {
             view.getMessages();
           } else if (py::isinstance<py::str>(topics)) {
             view.getMessages(topics.cast<std::string>());
-          } else if (py::isinstance<py::list>(topics)) {
-            view.getMessages(topics.cast<std::vector<std::string>>());
           } else {
-            throw std::runtime_error("topics must be None, a string, or a list!");
+            view.getMessages(topics.cast<std::vector<std::string>>());
           }
 
           return py::make_iterator(IteratorCompat{view.begin()}, IteratorCompat{view.end()});


### PR DESCRIPTION
Description of Changes
======================
#50 removed the ability to pass tuples (and other iterables that can be converted to `vector<std::string>`) as an argument to read_messages. This re-adds that support.

Test Plan
=========
Tests still run as expected.
